### PR TITLE
issue #6 Added External Java Download and Install Functionality

### DIFF
--- a/group_vars/java.yml
+++ b/group_vars/java.yml
@@ -1,0 +1,8 @@
+---
+#Install external Java if no internet connection or you want to use custom java
+external_java: true
+src_java_path: /root/jdk/files/
+#dont change dest java path until necessary
+dest_java_path: /tmp/jdk/
+# Always use otn-pub link instead of otn link as otn link required login
+jdk_dwonload_link: "http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.rpm"

--- a/roles/create_db/tasks/main.yml
+++ b/roles/create_db/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
+- include_vars: ../../../group_vars/create_db
 
 - name: Create databases
   mysql_db: login_user=root login_password={{ mysql_root_password }}
               name={{ item.value.name }} encoding=utf8 state=present
   with_dict: "{{ databases }}"
-
+  when: inventory_hostname in groups['db_server'][0]
 - name: Create database users
   mysql_user: login_user=root login_password={{ mysql_root_password }}
                 name={{ item.value.user }} password={{ item.value.pass }} update_password=always
                 priv={{ item.value.name }}.*:ALL host='%' state=present
   with_dict: "{{ databases }}"
+  when: inventory_hostname in groups['db_server'][0]

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -8,7 +8,8 @@
     path: "{{ src_java_path }}"
   register: stat_result
   when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java)
-
+  delegate_to: 127.0.0.1
+  
 - name: Download Java RPM
   get_url:
     url="{{ jdk_dwonload_link }}"

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -1,41 +1,106 @@
 ---
+- include_vars: ../../../group_vars/java
 
+# Check Java rpm exist in SRC location.
+
+- name: Check Java RPM exists
+  stat:
+    path: "{{ src_java_path }}"
+  register: stat_result
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java)
+
+- name: Download Java RPM
+  get_url:
+    url="{{ jdk_dwonload_link }}"
+    dest="{{ src_java_path }}"
+    headers="Cookie:oraclelicense=accept-securebackup-cookie"
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java) and (stat_result.stat.exists == False)
+  delegate_to: 127.0.0.1
+# copy external java from custom location
+- name: copy custom JDK for installation
+  synchronize:
+   src: "{{ src_java_path }}"
+   dest: "{{ dest_java_path }}"
+  # dest: "{{ cm_rpm_dest_dir }}"
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java)
+
+# Get JDK file name for installation
+- name: get jdk file name
+  find:
+    paths: "{{ dest_java_path }}"
+  register: jdk_file
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java)
+
+# Set path with filename
+- set_fact:
+    jdk_path: "{{ jdk_file.files.0.path }}"
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java)
+
+# Install RPM package
+- name: Install package.
+  yum:
+    name: "{{ jdk_path }}"
+    state: present
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java)
+
+- name: Cleanup tmp files
+  file:
+    path="{{ jdk_path }}"
+    state=absent
+  ignore_errors: True
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (external_java)
+
+
+
+# Installing Cloudera default JDK, Requires internet connection and
+# JDK to be copied either in local repo Or cloudera yum repo
 - name: Install Oracle JDK
   yum: name={{ item }} state=latest update_cache=yes
   with_items:
     - oracle-j2sdk1.7
     - unzip
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (not external_java)
 
+# Check JCE policy files exists
 - stat: path="{{ tmp_dir }}/UnlimitedJCEPolicyJDK7.zip"
   register: jce_zip_exists
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (not external_java)
 
+# Download JCE policy files from oracle
 - name: Download JCE unlimited policy
   get_url:
     url=http://download.oracle.com/otn-pub/java/jce/7/UnlimitedJCEPolicyJDK7.zip
     dest="{{ tmp_dir }}/UnlimitedJCEPolicyJDK7.zip"
     headers="Cookie:oraclelicense=accept-securebackup-cookie"
-  when: jce_zip_exists.stat.exists == False
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (not external_java)
 
+# Unzip JCE policy files
 - name: Unzip JCE unlimited policy files
   unarchive:
     src: "{{ tmp_dir }}/UnlimitedJCEPolicyJDK7.zip"
     dest: "{{ tmp_dir }}"
     copy: no
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (not external_java)
 
+# Install local_policy jars
 - name: Install local_policy.jar
   copy:
     src: "{{ tmp_dir }}/UnlimitedJCEPolicy/local_policy.jar"
     dest: /usr/java/jdk1.7.0_67-cloudera/jre/lib/security/local_policy.jar
     backup: yes
     remote_src: True
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (not external_java)
 
+# Install US_export_policy jars
 - name: Install US_export_policy.jar
   copy:
     src: "{{ tmp_dir }}/UnlimitedJCEPolicy/US_export_policy.jar"
     dest: /usr/java/jdk1.7.0_67-cloudera/jre/lib/security/US_export_policy.jar
     backup: yes
     remote_src: True
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (not external_java)
 
+# Cleaning up temp files
 - name: Cleanup tmp files
   file:
     path="{{ tmp_dir }}/{{ item }}"
@@ -44,3 +109,4 @@
     - UnlimitedJCEPolicy
     - UnlimitedJCEPolicyJDK7.zip
   ignore_errors: True
+  when: (ansible_distribution|lower == "redhat") or (ansible_distribution|lower == "centos") and (not external_java)

--- a/roles/mariadb/tasks/main.yml
+++ b/roles/mariadb/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-
+- include_vars: ../../../group_vars/db_server
 - name: Install MariaDB packages
   yum: name={{ item }} state=installed
   with_items:
@@ -21,6 +21,9 @@
   service: name=mariadb state=started enabled=yes
 
 - include: mysql_secure_installation.yml
-- include: databases.yml
 
 
+- include: mysql_master_setup.yml
+  when: mysql_replication
+- include: mysql_slave_setup.yml
+  when: mysql_replication

--- a/roles/mariadb/tasks/mysql_master_setup.yml
+++ b/roles/mariadb/tasks/mysql_master_setup.yml
@@ -1,0 +1,19 @@
+---
+# Change Configuration File to Master Configuration
+- name: Create MariaDB configuration file
+  template: src=my_master.cnf.j2 dest=/etc/my.cnf
+  when: (inventory_hostname in groups['db_server'][0])
+  notify:
+    - restart mariadb
+# Create Replication user in Master node
+- name: Create replication user
+  mysql_user:
+        login_user: root
+        login_password: "{{ mysql_root_password }}"
+        name: "{{ mysql_replication_user }}"
+        password: "{{ mysql_replication_password }}"
+        update_password: always
+        priv: "*.*:REPLICATION SLAVE,REPLICATION CLIENT"
+        host: "%"
+        state: present
+  when: (inventory_hostname in groups['db_server'][0])

--- a/roles/mariadb/tasks/mysql_slave_setup.yml
+++ b/roles/mariadb/tasks/mysql_slave_setup.yml
@@ -1,0 +1,63 @@
+---
+# Change Configuration File to Slave Configuration
+- name: Create MariaDB configuration file
+  template: src=my_slave.cnf.j2 dest=/etc/my.cnf
+  when: (inventory_hostname in groups['db_server'][1])
+  notify:
+    - restart mariadb
+
+# Get master binlog file name and binlog position
+- name: Check master replication status.
+  mysql_replication:
+    mode: getmaster
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  delegate_to: "{{ hostvars[groups['db_server'][0]]['inventory_hostname'] }}"
+  register: master
+
+- name: check replication slave status
+  mysql_replication:
+    mode: getslave
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  ignore_errors: true
+  when: (inventory_hostname in groups['db_server'][1])
+  register: slave
+
+# Start Replication on slave
+- name: Stop replication.
+  mysql_replication:
+    mode: stopslave
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  when: (inventory_hostname in groups['db_server'][1]) and (slave.Is_Slave)
+
+# Change master to master server and use binary log with position
+- name: Configure replication on slave.
+  mysql_replication:
+    mode: changemaster
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+    master_host: "{{ hostvars[groups['db_server'][0]]['inventory_hostname'] }}"
+    master_user: "{{ mysql_replication_user }}"
+    master_password: "{{ mysql_replication_password }}"
+    master_log_file: "{{ master.File }}"
+    master_log_pos: "{{ master.Position }}"
+  when: (inventory_hostname in groups['db_server'][1])
+
+# Start Replication on slave
+- name: Start replication.
+  mysql_replication:
+    mode: startslave
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  when: (inventory_hostname in groups['db_server'][1])
+
+- name: check replication slave status and see waitng
+  mysql_replication:
+    mode: getslave
+    login_user: root
+    login_password: "{{ mysql_root_password }}"
+  ignore_errors: true
+  when: (inventory_hostname in groups['db_server'][1])
+  register: slave_status

--- a/roles/mariadb/templates/my_master.cnf.j2
+++ b/roles/mariadb/templates/my_master.cnf.j2
@@ -43,3 +43,9 @@ innodb_log_file_size            = 512M
 [mysqld_safe]
 log-error = {{ mysql_log }}
 pid-file  = {{ mysql_pid_file }}
+
+[mariadb]
+log-bin = mysql-bin
+server-id = 1
+log-basename = master1
+bind-address=0.0.0.0

--- a/roles/mariadb/templates/my_slave.cnf.j2
+++ b/roles/mariadb/templates/my_slave.cnf.j2
@@ -43,3 +43,7 @@ innodb_log_file_size            = 512M
 [mysqld_safe]
 log-error = {{ mysql_log }}
 pid-file  = {{ mysql_pid_file }}
+
+[mariadb]
+server-id = 2
+bind-address=0.0.0.0


### PR DESCRIPTION
#29 Added External Java Download and Install Functionality.

There are 2 options for to use this functionality.
1. Download and Keep JDK file in src_java_path(change as per need)
2. Change jdk_dwonload_link to for download specific version of JDK  (If internet is available on Ansible host and not on server host)

Below are the new variables introduced for this functionality.
---
# Install external Java if no internet connection or you want to use custom java
# Always use otn-pub link instead of otn link as otn link requires login
external_java: true
src_java_path: /root/jdk/files/
#dont change dest java path until necessary
dest_java_path: /tmp/jdk/
jdk_dwonload_link: "http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.rpm"
